### PR TITLE
Made "Fizzler Output Relay" description better

### DIFF
--- a/packages/fizzler_out_relay/info.txt
+++ b/packages/fizzler_out_relay/info.txt
@@ -7,8 +7,8 @@
 	"ID"    "ITEM_BEE2_FIZZLER_OUT_RELAY"
 	"Description"
 		{
-		"" "Fizzler items do not work correctly when given an output."
-		"" "Place this over an emitter, and connect to the target."
+		"" "Place this Relay in the exact same box of the Sensor (or at the other end to make its selection easier), then connect it (the Relay) to its targets."
+		"" "This object is needed because Fizzler items do not work correctly when given an output."
 		}
 	"Unstyled" "1"
 	"Version"


### PR DESCRIPTION
Fizzler Output Relay doesn't have a clear description, and this could lead to confusion (see #3262).
This PR makes the description a little clearer.