### PR TITLE
Add more global settings for turrets

### DIFF
--- a/packages/styles/oldAp/resources/instances/50s/items/turret.vmf
+++ b/packages/styles/oldAp/resources/instances/50s/items/turret.vmf
@@ -30,6 +30,21 @@ world
 }
 entity
 {
+	"id" "14"
+	"classname" "func_instance_parms"
+	"parm1" "$super_damage integer 0"
+	"parm2" "$shoot_through_portals integer 0"
+	"origin" "0 0 32"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
 	"id" "4"
 	"classname" "point_template"
 	"spawnflags" "2"
@@ -48,7 +63,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$shoot_through_portals"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -64,7 +79,7 @@ entity
 	"targetname" "turret"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$super_damage"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"

--- a/packages/styles/oldAp/resources/instances/80s/items/turret.vmf
+++ b/packages/styles/oldAp/resources/instances/80s/items/turret.vmf
@@ -33,6 +33,8 @@ entity
 	"id" "61"
 	"classname" "func_instance_parms"
 	"parm1" "$turr_name target_destination turr"
+	"parm2" "$shoot_through_portals integer 0"
+	"parm3" "$super_damage integer 0"
 	"origin" "0 0 32"
 	editor
 	{
@@ -206,7 +208,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$super_damage"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -220,7 +222,7 @@ entity
 	"targetname" "turr"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$shoot_through_portals"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"

--- a/packages/styles/overgrown/resources/instances/over/items/turret_var1.vmf
+++ b/packages/styles/overgrown/resources/instances/over/items/turret_var1.vmf
@@ -30,6 +30,21 @@ world
 }
 entity
 {
+	"id" "11"
+	"classname" "func_instance_parms"
+	"parm1" "$super_damage integer 0"
+	"parm2" "$shoot_through_portals integer 0"
+	"origin" "0 -16 18.1517"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
 	"id" "4"
 	"classname" "point_template"
 	"spawnflags" "2"
@@ -48,7 +63,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$shoot_through_portals"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -64,7 +79,7 @@ entity
 	"targetname" "turret"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$super_damage"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"

--- a/packages/styles/overgrown/resources/instances/over/items/turret_var2.vmf
+++ b/packages/styles/overgrown/resources/instances/over/items/turret_var2.vmf
@@ -30,6 +30,21 @@ world
 }
 entity
 {
+	"id" "7"
+	"classname" "func_instance_parms"
+	"parm1" "$super_damage integer 0"
+	"parm2" "$shoot_through_portals integer 0"
+	"origin" "0.145911 -16 17.0168"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
 	"id" "4"
 	"classname" "point_template"
 	"spawnflags" "2"
@@ -48,7 +63,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$shoot_through_portals"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -64,7 +79,7 @@ entity
 	"targetname" "turret"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$super_damage"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"

--- a/packages/styles/overgrown/resources/instances/over/items/turret_var3.vmf
+++ b/packages/styles/overgrown/resources/instances/over/items/turret_var3.vmf
@@ -30,6 +30,21 @@ world
 }
 entity
 {
+	"id" "57"
+	"classname" "func_instance_parms"
+	"parm1" "$super_damage integer 0"
+	"parm2" "$shoot_through_portals integer 0"
+	"origin" "-1.28227 -16 15.7719"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
 	"id" "53"
 	"classname" "env_spark"
 	"angles" "0 180 0"
@@ -75,7 +90,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$shoot_through_portals"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -91,7 +106,7 @@ entity
 	"targetname" "turret"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$super_damage"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"

--- a/packages/styles/p1_style/resources/instances/p1/items/turret.vmf
+++ b/packages/styles/p1_style/resources/instances/p1/items/turret.vmf
@@ -30,6 +30,21 @@ world
 }
 entity
 {
+	"id" "350"
+	"classname" "func_instance_parms"
+	"parm1" "$super_damage integer 0"
+	"parm2" "$shoot_through_portals integer 0"
+	"origin" "0 0 32"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
 	"id" "337"
 	"classname" "comp_precache_model"
 	"angles" "90 0 0"
@@ -174,7 +189,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$shoot_through_portals"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -189,7 +204,7 @@ entity
 	"targetname" "turret"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$super_damage"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"

--- a/packages/valve/hazards/info.txt
+++ b/packages/valve/hazards/info.txt
@@ -55,8 +55,8 @@
 	
 "ConfigGroup"
 	{
-	"ID"    "VALVE_FIZZLER"
-	"Name"  "Fizzlers"
+	"ID"    "VALVE_HAZARDS"
+	"Name"  "Hazards"
 	"Widget"
 		{
 		"ID"      "FlinchBack"
@@ -67,5 +67,27 @@
 		"Label"   "Forgiving Laserfields"
 		
 		"Tooltip" "If the player walks into a LaserField, knock them back instead of outright killing them. If they fling into the field or force their way through, it will still kill them."
+		}
+	"Widget"
+		{
+		"ID"      "SuperTurret"
+		
+		"Type"    "Checkbox"
+		"Default" "0"
+		
+		"Label"   "Turret super damage"
+		
+		"Tooltip" "Setting this to true will scale the turret's damage by a very large amount."
+		}
+	"Widget"
+		{
+		"ID"      "ShootThroughPortals"
+		
+		"Type"    "Checkbox"
+		"Default" "0"
+		
+		"Label"   "Turrets shoot through portals"
+		
+		"Tooltip" "Turrets will not try to shoot through portals unless this is set."
 		}
 	}

--- a/packages/valve/hazards/info.txt
+++ b/packages/valve/hazards/info.txt
@@ -55,8 +55,8 @@
 	
 "ConfigGroup"
 	{
-	"ID"    "VALVE_HAZARDS"
-	"Name"  "Hazards"
+	"ID"    "VALVE_FIZZLER"
+	"Name"  "Fizzlers"
 	"Widget"
 		{
 		"ID"      "FlinchBack"

--- a/packages/valve/hazards/info.txt
+++ b/packages/valve/hazards/info.txt
@@ -68,6 +68,12 @@
 		
 		"Tooltip" "If the player walks into a LaserField, knock them back instead of outright killing them. If they fling into the field or force their way through, it will still kill them."
 		}
+	}
+	
+"ConfigGroup"
+	{
+	"ID"    "VALVE_HAZARDS"
+	"Name"  "Hazards"
 	"Widget"
 		{
 		"ID"      "SuperTurret"

--- a/packages/valve/hazards/items/turret.cfg
+++ b/packages/valve/hazards/items/turret.cfg
@@ -10,6 +10,20 @@
 				"Deadly"	"1"
 				"Turret"	"1"
 				}
+			"GetItemConfig"
+				{
+				"ID"        "VALVE_HAZARDS"
+                "Name"      "SuperTurret"
+                "resultVar" "$super_damage"
+                "Default"   "0"
+                }
+			"GetItemConfig"
+				{
+				"ID"        "VALVE_HAZARDS"
+                "Name"      "ShootThroughPortals"
+                "resultVar" "$shoot_through_portals"
+                "Default"   "0"
+                }
 			}
 		}
 	}

--- a/packages/valve/hazards/resources/instances/clean/items/turret.vmf
+++ b/packages/valve/hazards/resources/instances/clean/items/turret.vmf
@@ -30,6 +30,21 @@ world
 }
 entity
 {
+	"id" "35"
+	"classname" "func_instance_parms"
+	"parm1" "$super_damage integer 0"
+	"parm2" "$shoot_through_portals integer 0"
+	"origin" "0 0 32"
+	editor
+	{
+		"color" "220 30 220"
+		"visgroupshown" "1"
+		"visgroupautoshown" "1"
+		"logicalpos" "[0 1500]"
+	}
+}
+entity
+{
 	"id" "4"
 	"classname" "point_template"
 	"spawnflags" "2"
@@ -48,7 +63,7 @@ entity
 {
 	"id" "2"
 	"classname" "npc_portal_turret_floor"
-	"AllowShootThroughPortals" "0"
+	"AllowShootThroughPortals" "$shoot_through_portals"
 	"angles" "0 180 0"
 	"CollisionType" "0"
 	"DamageForce" "1"
@@ -62,7 +77,7 @@ entity
 	"targetname" "turret"
 	"TurretRange" "1024"
 	"UsedAsActor" "0"
-	"UseSuperDamageScale" "0"
+	"UseSuperDamageScale" "$super_damage"
 	connections
 	{
 		"OnExplode" "@voice_turret_diedFireUser10-1"


### PR DESCRIPTION
For #3479 

Adds a "Super Damage" setting that toggles super damage mode for all turrets
Adds a "Shoot through portals" setting that controls whether or not turrets can shoot through portals

Also renames the "Fizzler" settings group (currently with a single laserfield setting) to "Hazards", and includes turrets in that grouping.