### PR TITLE
Copy checkpoint entity counts over from editoritems.txt

### DIFF
--- a/packages/tspen/checkpoint/items/coop_check_clean/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_clean/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"9"  
+	"ent_count"		"13"  
 	"Icon"
 		{
 			"0"		"clean/tspen/coop_checkpoint.png"

--- a/packages/tspen/checkpoint/items/coop_check_clean/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_clean/properties.txt
@@ -2,6 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
+	"ent_count"		"9"  
 	"Icon"
 		{
 			"0"		"clean/tspen/coop_checkpoint.png"

--- a/packages/tspen/checkpoint/items/coop_check_clean/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_clean/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"13"  
+	"ent_count"		"17"  
 	"Icon"
 		{
 			"0"		"clean/tspen/coop_checkpoint.png"

--- a/packages/tspen/checkpoint/items/coop_check_over/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_over/properties.txt
@@ -2,6 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
+	"ent_count"		"9"  
 	"Icon"
 		{
 			"0"		"over/tspen/coop_checkpoint.png"

--- a/packages/tspen/checkpoint/items/coop_check_over/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_over/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"9"  
+	"ent_count"		"13"  
 	"Icon"
 		{
 			"0"		"over/tspen/coop_checkpoint.png"

--- a/packages/tspen/checkpoint/items/coop_check_over/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_over/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"13"  
+	"ent_count"		"17"  
 	"Icon"
 		{
 			"0"		"over/tspen/coop_checkpoint.png"

--- a/packages/tspen/checkpoint/items/coop_check_sep_clean/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_sep_clean/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"9"  
+	"ent_count"		"13"  
 	"Description"	
 		{
 		"" "A version of the checkpoint room which will separate players after they exit."

--- a/packages/tspen/checkpoint/items/coop_check_sep_clean/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_sep_clean/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"13"  
+	"ent_count"		"17"  
 	"Description"	
 		{
 		"" "A version of the checkpoint room which will separate players after they exit."

--- a/packages/tspen/checkpoint/items/coop_check_sep_clean/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_sep_clean/properties.txt
@@ -2,6 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
+	"ent_count"		"9"  
 	"Description"	
 		{
 		"" "A version of the checkpoint room which will separate players after they exit."

--- a/packages/tspen/checkpoint/items/coop_check_sep_over/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_sep_over/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"9"  
+	"ent_count"		"13"  
 	"Description"	
 		{
 		"" "A version of the checkpoint room which will separate players after they exit."

--- a/packages/tspen/checkpoint/items/coop_check_sep_over/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_sep_over/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
-	"ent_count"		"13"  
+	"ent_count"		"17"  
 	"Description"	
 		{
 		"" "A version of the checkpoint room which will separate players after they exit."

--- a/packages/tspen/checkpoint/items/coop_check_sep_over/properties.txt
+++ b/packages/tspen/checkpoint/items/coop_check_sep_over/properties.txt
@@ -2,6 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - New Items"
+	"ent_count"		"9"  
 	"Description"	
 		{
 		"" "A version of the checkpoint room which will separate players after they exit."

--- a/packages/tspen/checkpoint/items/sp_check/properties.txt
+++ b/packages/tspen/checkpoint/items/sp_check/properties.txt
@@ -2,6 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - Modified Items"
+	"ent_count"		"55"  // from editoritems.txt, but I'm not sure if this is correct? hammer says 13.
 	"Icon"
 		{
 			"0"		"clean/tspen/chamberlock.png"

--- a/packages/tspen/checkpoint/items/sp_check/properties.txt
+++ b/packages/tspen/checkpoint/items/sp_check/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - Modified Items"
-	"ent_count"		"13"  
+	"ent_count"		"17"  
 	"Icon"
 		{
 			"0"		"clean/tspen/chamberlock.png"

--- a/packages/tspen/checkpoint/items/sp_check/properties.txt
+++ b/packages/tspen/checkpoint/items/sp_check/properties.txt
@@ -2,7 +2,7 @@
 	{
 	"Authors"		"TeamSpen210"
 	"Tags"			"BEE 2 Addons;TS - Modified Items"
-	"ent_count"		"55"  // from editoritems.txt, but I'm not sure if this is correct? hammer says 13.
+	"ent_count"		"13"  
 	"Icon"
 		{
 			"0"		"clean/tspen/chamberlock.png"


### PR DESCRIPTION
For #937 

Leaving this as a draft PR specifically due to https://github.com/BEEmod/BEE2-items/pull/3492/files#diff-4a04b88774b41001a32b3b1761656e7a; In hammer, the instance only takes 13 entities, but editoritems is set to 55. Not sure if this is correct, or if I'm miscounting. 