### PR TITLE
Fix Special Markers

### DIFF
--- a/packages/blocks/items/special_marker/vbsp_config.cfg
+++ b/packages/blocks/items/special_marker/vbsp_config.cfg
@@ -7,9 +7,9 @@
 			{
 			"AlterTexture"
 				{
-				"Dir" "0 0 -1"
+				"Dir" "0 0 1"
 				"Pos" "0 0 0"
-				"Tex" "<special>"
+				"Tex" "tile/white_wall_tile004j"
 				}
 			"ChangeInstance" ""
 			}


### PR DESCRIPTION
in latest version special markers not working.
my changes below changes its `"AlterTexture"` orientation to the correct one as well as changing texture to fixed value (variant with just `<special>` didnt work, so i assumed it was for some kind of functionality that was not implemented, thats why im changing this to a fixed texture)