### PR TITLE
Add option for piston downward speed

### DIFF
--- a/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
+++ b/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
@@ -155,7 +155,7 @@ function _up() {
 	for(local i=1; i<=pos; i++) {
 		if (positions[i] != POS_UP) {
 			positions[i] = POS_MOVING;
-			pistons[i].__KeyValueFromFloat("speed",SPEED_UP);//From init_code
+			EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_UP, 0, self, self);//From init_code
 			EntFireByHandle(pistons[i], "Open", "", 0, self, self);
 			if (desired_direction == 0) {
 				EntFireByHandle(self, "RunScriptCode", "verifyDirection(POS_UP)", 0.01, self, self);
@@ -185,7 +185,7 @@ function _dn() {
 	for(local i=4; i>pos; i--) {
 		if (positions[i] != POS_DN) {
 			positions[i] = POS_MOVING;
-			pistons[i].__KeyValueFromFloat("speed",SPEED_DOWN);//From init_code
+			EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_DOWN, 0, self, self);//From init_code
 			EntFireByHandle(pistons[i], "Close", "", 0, self, self);
 			if (desired_direction == 0) {
 				EntFireByHandle(self, "RunScriptCode", "verifyDirection(POS_DN)", 0.01, self, self);

--- a/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
+++ b/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
@@ -35,6 +35,9 @@ verify_clock <- 0;//Clock to verify that no inputs butt to the front of the line
 
 START_SND <- "";
 STOP_SND <- "";
+// If not set (old map), these are equal and SetSpeed isn't fired.
+SPEED_UP <- -1;
+SPEED_DOWN <- -1;
 
 // If true, we spawned extended.
 SPAWN_UP <- false;
@@ -82,7 +85,13 @@ function OnPostSpawn() {
 	if (SPAWN_UP) {
 		pos = highest_pos;
 	}
-	
+	if (SPEED_UP < 0) {
+		SPEED_UP = SPEED_DOWN;
+	}
+	if (SPEED_DOWN < 0) {
+		SPEED_DOWN = SPEED_UP;
+	}
+
 	snd_top_ent <- self.GetMoveParent();
 	if (snd_top_ent != null) {
 		// We now know what it is.
@@ -155,8 +164,8 @@ function _up() {
 	for(local i=1; i<=pos; i++) {
 		if (positions[i] != POS_UP) {
 			positions[i] = POS_MOVING;
-			if (SPEED_DOWN != SPEED_UP) {//From init_code
-				EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_UP, 0, self, self);
+			if (SPEED_DOWN != SPEED_UP) { //From init_code
+				EntFireByHandle(pistons[i], "SetSpeed", SPEED_UP.tostring(), 0, self, self);
 			}
 			EntFireByHandle(pistons[i], "Open", "", 0, self, self);
 			if (desired_direction == 0) {
@@ -188,7 +197,7 @@ function _dn() {
 		if (positions[i] != POS_DN) {
 			positions[i] = POS_MOVING;
 			if (SPEED_DOWN != SPEED_UP) {//From init_code
-				EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_DOWN, 0, self, self);
+				EntFireByHandle(pistons[i], "SetSpeed", SPEED_DOWN.tostring(), 0, self, self);
 			}
 			EntFireByHandle(pistons[i], "Close", "", 0, self, self);
 			if (desired_direction == 0) {

--- a/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
+++ b/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
@@ -155,7 +155,9 @@ function _up() {
 	for(local i=1; i<=pos; i++) {
 		if (positions[i] != POS_UP) {
 			positions[i] = POS_MOVING;
-			EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_UP, 0, self, self);//From init_code
+			if (SPEED_DOWN != SPEED_UP) {//From init_code
+				EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_UP, 0, self, self);
+			}
 			EntFireByHandle(pistons[i], "Open", "", 0, self, self);
 			if (desired_direction == 0) {
 				EntFireByHandle(self, "RunScriptCode", "verifyDirection(POS_UP)", 0.01, self, self);
@@ -185,7 +187,9 @@ function _dn() {
 	for(local i=4; i>pos; i--) {
 		if (positions[i] != POS_DN) {
 			positions[i] = POS_MOVING;
-			EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_DOWN, 0, self, self);//From init_code
+			if (SPEED_DOWN != SPEED_UP) {//From init_code
+				EntFireByHandle(pistons[i], "SetSpeed", ""+SPEED_DOWN, 0, self, self);
+			}
 			EntFireByHandle(pistons[i], "Close", "", 0, self, self);
 			if (desired_direction == 0) {
 				EntFireByHandle(self, "RunScriptCode", "verifyDirection(POS_DN)", 0.01, self, self);

--- a/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
+++ b/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
@@ -147,6 +147,7 @@ function _up() {
 	for(local i=1; i<=pos; i++) {
 		if (positions[i] != POS_UP) {
 			positions[i] = POS_MOVING;
+			pistons[i].__KeyValueFromFloat("speed",SPEED_UP);//From init_code
 			EntFireByHandle(pistons[i], "Open", "", 0, self, self);
 			cur_moving = i;
 			return;
@@ -167,6 +168,7 @@ function _dn() {
 	for(local i=4; i>pos; i--) {
 		if (positions[i] != POS_DN) {
 			positions[i] = POS_MOVING;
+			pistons[i].__KeyValueFromFloat("speed",SPEED_DOWN);//From init_code
 			EntFireByHandle(pistons[i], "Close", "", 0, self, self);
 			cur_moving = i;
 			door_pos = pistons[i].GetOrigin();

--- a/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
+++ b/packages/valve/clean_style/resources/scripts/vscripts/BEE2/piston/common.nut
@@ -28,6 +28,10 @@ POS_DN <- -1;
 POS_MOVING <- 0;
 positions <- {};
 cur_moving <- -1;
+//Set for the tick that _up or _down gets called
+desired_direction <- 0;
+verify_clock <- 0;//Clock to verify that no inputs butt to the front of the line
+//INFINITESIMAL_TICK = 3.8146977e-6;
 
 START_SND <- "";
 STOP_SND <- "";
@@ -144,11 +148,20 @@ function moveto(new_pos) {
 // and trigger it.
 // The pistons then trigger them again when they finish, so we loop until done.
 function _up() {
+	if (desired_direction && verify_clock != Time()) {//Caused by I/O logic butting in line
+		EntFireByHandle(self, "CallScriptFunction", "_up", 0, self, self);//Push to the end of the I/O queue after verifyDirection
+		return;
+	}
 	for(local i=1; i<=pos; i++) {
 		if (positions[i] != POS_UP) {
 			positions[i] = POS_MOVING;
 			pistons[i].__KeyValueFromFloat("speed",SPEED_UP);//From init_code
 			EntFireByHandle(pistons[i], "Open", "", 0, self, self);
+			if (desired_direction == 0) {
+				EntFireByHandle(self, "RunScriptCode", "verifyDirection(POS_UP)", 0.01, self, self);
+				verify_clock = Time();
+			}
+			desired_direction <- POS_UP;
 			cur_moving = i;
 			return;
 		}
@@ -164,12 +177,21 @@ function _up() {
 }
 
 function _dn() {
+	if (desired_direction && verify_clock != Time()) {//Caused by I/O logic butting in line
+		EntFireByHandle(self, "CallScriptFunction", "_dn", 0, self, self);//Push to the end of the I/O queue so that verifyDirection runs before this
+		return;
+	}
 	// Do not include piston[pos].
 	for(local i=4; i>pos; i--) {
 		if (positions[i] != POS_DN) {
 			positions[i] = POS_MOVING;
 			pistons[i].__KeyValueFromFloat("speed",SPEED_DOWN);//From init_code
 			EntFireByHandle(pistons[i], "Close", "", 0, self, self);
+			if (desired_direction == 0) {
+				EntFireByHandle(self, "RunScriptCode", "verifyDirection(POS_DN)", 0.01, self, self);
+				verify_clock <- Time();
+			}
+			desired_direction <- POS_DN;
 			cur_moving = i;
 			door_pos = pistons[i].GetOrigin();
 			crush_count = 0;
@@ -191,6 +213,21 @@ function _dn() {
 		foreach (fizz in dn_fizz_ents) {
 			EntFireByHandle(fizz, "Disable", "", 0, self, self);
 		}
+	}
+}
+
+function verifyDirection(original_direction) {
+	if (original_direction == desired_direction) {
+		desired_direction <- 0;//Nothing to correct
+	} else if (desired_direction == POS_UP) {
+		desired_direction <- 0;//Repeat verification
+		_up();
+	} else if (desired_direction == POS_DN) {
+		desired_direction <- 0;//Repeat verification
+		_dn();
+	} else {
+		printl("Incorrect piston behavior");
+		desired_direction <- 0;
 	}
 }
 

--- a/packages/valve/geometry/info.txt
+++ b/packages/valve/geometry/info.txt
@@ -53,8 +53,20 @@
 		"Max"     "200"
 		"Step"    "25"
 
-		"Label"   "Piston Platform Speed"
-		"Tooltip" "Allows customising the movement speed for Piston Platforms. This is measured in Hammer units per second - a Puzzlemaker voxel is 128 units across. Puzzlemaker defaults to 150u/s, while the campaign tends to use values of 100 or 150 depending on the map."
+		"Label"   "Piston Platform Up Speed"
+		"Tooltip" "Allows customising the movement speed for Piston Platforms moving up. This is measured in Hammer units per second - a Puzzlemaker voxel is 128 units across. Puzzlemaker defaults to 150u/s, while the campaign tends to use values of 100 or 150 depending on the map."
+		}
+	"Widget"
+		{
+		"ID"      "PistonPlatDownSpeed"
+		"Type"    "Slider"
+		"Default" "150"
+		"Min"     "25"
+		"Max"     "200"
+		"Step"    "25"
+
+		"Label"   "Piston Platform Down Speed"
+		"Tooltip" "Allows customising the movement speed for Piston Platforms moving down. This is measured in Hammer units per second - a Puzzlemaker voxel is 128 units across. Puzzlemaker defaults to 150u/s, while the campaign tends to use values of 100 or 150 depending on the map."
 		}
 	"Widget"
 		{

--- a/packages/valve/geometry/items/piston_plat/vbsp_config.cfg
+++ b/packages/valve/geometry/items/piston_plat/vbsp_config.cfg
@@ -100,6 +100,13 @@
                 "resultVar" "$speed"
                 "Default"   "150"
                 }
+			"GetItemConfig"
+				{
+				"ID"        "VALVE_TEST_ELEM"
+                "Name"      "PistonPlatDownSpeed"
+                "resultVar" "$down_speed"
+                "Default"   "150"
+                }
 			}
 		"Condition"
 			{
@@ -131,6 +138,7 @@
 					"source_ent" "platform"
 					"auto_var"   "$disable_autodrop"
 					"speed"      "$speed"
+					"down_speed" "$down_speed"
 					"dn_fizz_name" "dn_fizz"
 					}
 				}
@@ -173,6 +181,7 @@
 					"source_ent" "platform"
 					"auto_var"   "$disable_autodrop"
 					"speed"      "$speed"
+					"down_speed" "$down_speed"
 					"dn_fizz_name" "dn_fizz"
 					}
 				}


### PR DESCRIPTION
Sets the speed of the segment to move to the appropriate speed
Rename and redescribe original widget to indicate that it is the speed that the piston moves upward
Added new widget for downward piston speed
Gets downward piston speed in `vbsp_config` and passes it to `PistonPlatform`
Fixed frame perfect I/O break where the platform doesn't turn around:
- Sets `desired_direction` in `_up` and `_dn` in segment code
- If `desired_direction` is not set in segment code, calls `verifyDirection` with the original direction and records the time in `verify_clock` to determine if (strictly) future calls to `_up` and `_dn` happen before `verifyDirection`
- If `desired_direction` is set in `_up` and `_dn`, checks to make sure it is called in the same tick before preceding, otherwise pushes the call to the end of the I/O queue
- Added `verifyDirection` function which resets the direction, but first checks the parameter with the last set direction, and if different, calls `_up` or `_dn` depending on the direction it needs to go in after resetting the direction